### PR TITLE
1.3.5 Update

### DIFF
--- a/Pokemon Shuffle Save Editor/Cheats.cs
+++ b/Pokemon Shuffle Save Editor/Cheats.cs
@@ -30,7 +30,7 @@ namespace Pokemon_Shuffle_Save_Editor
 
         private void B_CaughtEverything_Click(object sender, EventArgs e)
         {
-            for (int i = 1; i < 780; i++)
+            for (int i = 1; i < 883; i++) //includes 15 reserved slots
             {
                 SetPokemon(i, true);
             }
@@ -84,14 +84,15 @@ namespace Pokemon_Shuffle_Save_Editor
 
         private void B_Level10_Click(object sender, EventArgs e)
         {
-            for (int i = 0; i < 780; i++)
+            for (int i = 0; i < 883; i++) //Updated range
             {
                 if (GetPokemon(i))
                 {
-                    SetLevel(i, 10);
+                    int max = 10 + ((BitConverter.ToUInt16(savedata, 0xA9DB + ((i * 6) / 8)) >> ((i * 6) % 8)) & 0x3F); //Reads the amount of lollipops used on that pokemon & set level to current Max.
+                    SetLevel(i, max);                                                                                   //May behave poorly if lollipops > 5 (needs testing)
                 }
             }
-            MessageBox.Show("Everything you've caught is now level 10.");
+            MessageBox.Show("Everything you've caught is now level Max.");
         }
 
         private void B_MaxResources_Click(object sender, EventArgs e)
@@ -105,7 +106,10 @@ namespace Pokemon_Shuffle_Save_Editor
                 val |= (99 << 7);
                 Array.Copy(BitConverter.GetBytes(val), 0, savedata, 0xd0 + i, 2);
             }
-            savedata[0x2D4C] = (byte)((((99) << 1) & 0xFE) | (savedata[0x2D4C] & 1)); // Mega Speedups
+            for (int i = 0; i < 9; i++)
+            {
+                savedata[0x2D4C + i] = (byte)((((99) << 1) & 0xFE) | (savedata[0x2D4C + i] & 1)); // Mega Speedups & other items
+            }
             MessageBox.Show("Gave 99 hearts, 99999 coins, 150 jewels, and 99 of every item.");
         }
 

--- a/Pokemon Shuffle Save Editor/Form1.Designer.cs
+++ b/Pokemon Shuffle Save Editor/Form1.Designer.cs
@@ -62,6 +62,7 @@
             this.CB_MonIndex = new System.Windows.Forms.ComboBox();
             this.PB_Mon = new System.Windows.Forms.PictureBox();
             this.GB_Resources = new System.Windows.Forms.GroupBox();
+            this.ItemsGrid = new System.Windows.Forms.PropertyGrid();
             this.NUP_Jewels = new System.Windows.Forms.NumericUpDown();
             this.NUP_Coins = new System.Windows.Forms.NumericUpDown();
             this.NUP_Hearts = new System.Windows.Forms.NumericUpDown();
@@ -69,7 +70,6 @@
             this.label12 = new System.Windows.Forms.Label();
             this.label11 = new System.Windows.Forms.Label();
             this.B_CheatsForm = new System.Windows.Forms.Button();
-            this.ItemsGrid = new System.Windows.Forms.PropertyGrid();
             this.GB_HighScore.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.NUP_EventScore)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.NUP_EventIndex)).BeginInit();
@@ -339,7 +339,7 @@
             // CHK_MegaX
             // 
             this.CHK_MegaX.AutoSize = true;
-            this.CHK_MegaX.Location = new System.Drawing.Point(166, 79);
+            this.CHK_MegaX.Location = new System.Drawing.Point(170, 79);
             this.CHK_MegaX.Name = "CHK_MegaX";
             this.CHK_MegaX.Size = new System.Drawing.Size(15, 14);
             this.CHK_MegaX.TabIndex = 21;
@@ -349,7 +349,7 @@
             // CHK_MegaY
             // 
             this.CHK_MegaY.AutoSize = true;
-            this.CHK_MegaY.Location = new System.Drawing.Point(104, 79);
+            this.CHK_MegaY.Location = new System.Drawing.Point(108, 79);
             this.CHK_MegaY.Name = "CHK_MegaY";
             this.CHK_MegaY.Size = new System.Drawing.Size(15, 14);
             this.CHK_MegaY.TabIndex = 20;
@@ -429,6 +429,51 @@
             this.GB_Resources.TabStop = false;
             this.GB_Resources.Text = "Resources";
             // 
+            // ItemsGrid
+            // 
+            this.ItemsGrid.Location = new System.Drawing.Point(6, 77);
+            this.ItemsGrid.Name = "ItemsGrid";
+            shuffleItems1.AttackUp = 0;
+            shuffleItems1.Complexity = 0;
+            shuffleItems1.Disruption = 0;
+            shuffleItems1.Enchantments = new int[] {
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0};
+            shuffleItems1.Experience = 0;
+            shuffleItems1.ExperienceBoostL = 0;
+            shuffleItems1.ExperienceBoostM = 0;
+            shuffleItems1.ExperienceBoostS = 0;
+            shuffleItems1.Items = new int[] {
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0};
+            shuffleItems1.LevelUp = 0;
+            shuffleItems1.MegaSpeedup = 0;
+            shuffleItems1.MegaStart = 0;
+            shuffleItems1.Moves = 0;
+            shuffleItems1.RaiseMaxLevel = 0;
+            shuffleItems1.SkillBoosterL = 0;
+            shuffleItems1.SkillBoosterM = 0;
+            shuffleItems1.SkillBoosterS = 0;
+            shuffleItems1.Time = 0;
+            this.ItemsGrid.SelectedObject = shuffleItems1;
+            this.ItemsGrid.Size = new System.Drawing.Size(241, 235);
+            this.ItemsGrid.TabIndex = 27;
+            this.ItemsGrid.ToolbarVisible = false;
+            this.ItemsGrid.PropertyValueChanged += new System.Windows.Forms.PropertyValueChangedEventHandler(this.UpdateProperty);
+            this.ItemsGrid.EnabledChanged += new System.EventHandler(this.ItemsGrid_EnabledChanged);
+            // 
             // NUP_Jewels
             // 
             this.NUP_Jewels.Location = new System.Drawing.Point(190, 51);
@@ -506,56 +551,11 @@
             this.B_CheatsForm.UseVisualStyleBackColor = true;
             this.B_CheatsForm.Click += new System.EventHandler(this.B_CheatsForm_Click);
             // 
-            // ItemsGrid
-            // 
-            this.ItemsGrid.Location = new System.Drawing.Point(6, 77);
-            this.ItemsGrid.Name = "ItemsGrid";
-            shuffleItems1.AttackUp = 0;
-            shuffleItems1.Complexity = 0;
-            shuffleItems1.Disruption = 0;
-            shuffleItems1.Enchantments = new int[] {
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0};
-            shuffleItems1.Experience = 0;
-            shuffleItems1.ExperienceBoostL = 0;
-            shuffleItems1.ExperienceBoostM = 0;
-            shuffleItems1.ExperienceBoostS = 0;
-            shuffleItems1.Items = new int[] {
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0};
-            shuffleItems1.LevelUp = 0;
-            shuffleItems1.MegaSpeedup = 0;
-            shuffleItems1.MegaStart = 0;
-            shuffleItems1.Moves = 0;
-            shuffleItems1.RaiseMaxLevel = 0;
-            shuffleItems1.SkillBoosterL = 0;
-            shuffleItems1.SkillBoosterM = 0;
-            shuffleItems1.SkillBoosterS = 0;
-            shuffleItems1.Time = 0;
-            this.ItemsGrid.SelectedObject = shuffleItems1;
-            this.ItemsGrid.Size = new System.Drawing.Size(241, 235);
-            this.ItemsGrid.TabIndex = 27;
-            this.ItemsGrid.ToolbarVisible = false;
-            this.ItemsGrid.PropertyValueChanged += new System.Windows.Forms.PropertyValueChangedEventHandler(this.UpdateProperty);
-            this.ItemsGrid.EnabledChanged += new System.EventHandler(this.ItemsGrid_EnabledChanged);
-            // 
             // Form1
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(519, 455);
+            this.ClientSize = new System.Drawing.Size(519, 454);
             this.Controls.Add(this.B_CheatsForm);
             this.Controls.Add(this.GB_Resources);
             this.Controls.Add(this.GB_Caught);

--- a/Pokemon Shuffle Save Editor/Form1.cs
+++ b/Pokemon Shuffle Save Editor/Form1.cs
@@ -61,9 +61,9 @@ namespace Pokemon_Shuffle_Save_Editor
             {
                 int entrylen = BitConverter.ToInt32(mondata,0x4);
                 byte[] data = mondata.Skip(0x50 + entrylen * i).Take(entrylen).ToArray();
-                bool isMega = i > 867 && i < 919; //changed this because the index was changed
+                bool isMega = i > 882 && i < 934; //changed this because the index was changed
                 int spec = isMega
-                    ? specieslist.ToList().IndexOf(monslist[megas[i - 868]].Replace("Shiny","").Replace("Winking","").Replace("Smiling","").Replace(" ","")) //crappy but needed for IndexOf() to find the pokemon's name in specieslist (only adjectives on megas names matter)
+                    ? specieslist.ToList().IndexOf(monslist[megas[i - 883]].Replace("Shiny","").Replace("Winking","").Replace("Smiling","").Replace(" ","")) //crappy but needed for IndexOf() to find the pokemon's name in specieslist (only adjectives on megas names matter)
                     : (BitConverter.ToInt32(data, 0xE) >> 6) & 0x7FF; //this changed too, also updated the resources.resx file
                 mons[i] = new Tuple<int, int, bool>(spec, forms[spec], isMega);
                 forms[spec]++;
@@ -265,7 +265,9 @@ namespace Pokemon_Shuffle_Save_Editor
         private Bitmap GetMonImage(int mon_num, int form = 0, bool mega = false)
         {
             string imgname = string.Empty;
-            if (mega)
+            if (mega && !HasMega[mon_num][1]) //pretty hacky but necessary to differenciate Rayquaza/Gyarados from Charizard/Mewtwo
+                form -= 2;                    
+            if (mega && HasMega[mon_num][1])  //Otherwise, either stage 300 is Shiny M-Ray or stage 150 is M-mewtwo X
                 form--;
             if (mega)
                 imgname += "mega_";

--- a/Pokemon Shuffle Save Editor/Pokemon Shuffle Save Editor.csproj
+++ b/Pokemon Shuffle Save Editor/Pokemon Shuffle Save Editor.csproj
@@ -1189,7 +1189,6 @@
     <None Include="Resources\img\pokemon_718_01.png" />
     <Content Include="Resources\img\pokemon_718_02.png" />
     <Content Include="Resources\img\pokemon_719.png" />
-    <None Include="Resources\pokemon_718_02.bmp" />
     <None Include="Resources\img\pokemon_720.png" />
     <None Include="Resources\img\pokemon_720_01.png" />
     <None Include="Resources\img\pokemon_721.png" />

--- a/Pokemon Shuffle Save Editor/Resources/txt/mons.txt
+++ b/Pokemon Shuffle Save Editor/Resources/txt/mons.txt
@@ -866,6 +866,21 @@ Pumpkaboo Smiling
 Gourgeist Smiling
 Zygarde 10% Forme
 Zygarde Complete Forme
+---
+---
+---
+---
+---
+---
+---
+---
+---
+---
+---
+---
+---
+---
+---
 Mega Venusaur
 Mega Charizard X
 Mega Charizard Y


### PR DESCRIPTION
Fixed mons.txt
Fixed mega stages sprites
Updated resource files reading
Updated Cheats to 1.3.5
"All Caught to lvl 10" now sets level to Max, depending on current number of lollipops given.

StageDataEvent is empty so only Meowth can be viewed until the location of other Event stages is found.

Hopefully this commit will merge correctly.
